### PR TITLE
update for new VC profiler

### DIFF
--- a/src/vividcortex.coffee
+++ b/src/vividcortex.coffee
@@ -1,22 +1,15 @@
 # Description:
-#   Renders VividCortex components as images
+#   Renders VividCortex profiler as images
 #
 # Configuration:
-#   HUBOT_VC_ORGANIZATION # This is the organization nickname, you'll see it in the VividCortex app URL
 #   HUBOT_VC_ENVIRONMENT # This is the environment ID, you'll see it in the VividCortex app URL too
 #   HUBOT_VC_TOKEN # This is the same token used to install VividCortex
 #
 # Commands:
-#   hubot <vividcortex|vc> <top-queries|query-compare|top-processes> last <count> <seconds|minutes|hours|days|month> - Generate a capture of the specified component
-#   hubot <vividcortex|vc> <top-queries|query-compare|top-processes> last minute|hour|month
-#   hubot <vividcortex|vc> query-compare last N seconds
-#   hubot <vividcortex|vc> top-processes last 10 minutes
-#   hubot <vividcortex|vc> top-queries last 20 days
-#   hubot <vividcortex|vc> share top-queries last 3 months
-#
-# Notes:
-#   - Does not support graphs at the moment
-#   - The second parameter only accepts "last" as a option, the plan is making it support multiple values like timestamps.
+#   hubot <vividcortex|vc> <count> minute|hour|day|month
+#   hubot <vividcortex|vc> 30 minutes
+#   hubot <vividcortex|vc> 12 hours
+#   hubot <vividcortex|vc> 2 days
 #
 # Author:
 #   cesarvarela
@@ -24,10 +17,9 @@
 # VividCortex api URL
 
 api = "https://app.vividcortex.com/api/v2"
+host = ""  # specify a host e.g. id=99 to restrict to a single host
 
 # Config
-
-ORGANIZATION = process.env.HUBOT_VC_ORGANIZATION
 ENVIRONMENT = process.env.HUBOT_VC_ENVIRONMENT
 TOKEN = process.env.HUBOT_VC_TOKEN
 
@@ -35,10 +27,6 @@ module.exports = (robot) ->
 
 
   environmentIsOk = (msg) ->
-
-    unless ORGANIZATION?
-      msg.send "Missing HUBOT_VC_ORGANIZATION in environment: please set and try again"
-      return false
 
     unless ENVIRONMENT?
       msg.send "Missing HUBOT_VC_ENVIRONMENT in environment: please set and try again"
@@ -50,55 +38,32 @@ module.exports = (robot) ->
 
     return true # thanks coffeescript, but I like my returns
 
-  urls =
-
-  # Customizing this URLS allow us to add/remove columns, filters, sort by, etc.
-
-    "top-queries"   : "/top-queries?limit=5&hosts="
-    "query-compare" : "/query-compare?limit=5&hosts="
-    "top-processes" : "/top-processes?limit=5&hosts="
-
 
   # Generates the url to be loaded before generating the screenshot,
-  # the <since> parameter is going to be used in the future
 
-  getURL = (component, since, count, unit) ->
+  getURL = (count, unit) ->
 
-    base = "/#{ORGANIZATION}/#{ENVIRONMENT}"
+    base = api + "/share/capture?selector=" + encodeURIComponent('[vc-shareable="profiler-table"]') + "&url="
+    url_arg = "/#{ENVIRONMENT}/profiler?rank=queries&by=time&orderBy=-time"
+    url_arg = url_arg + "&hosts=#{host}&limit=10&filterBy=&filterByTagName=&filterByTagValue=&scaleCpuMode=false"
+    url_arg = url_arg + "&compare=false&cols=rank&cols=time&cols=throughput&cols=latency&cols=queryNotifications"
+    url_arg = url_arg + "&cols=userCpu&cols=systemCpu&cols=residentMemory&cols=virtualMemory&cols=bytesRead"
+    url_arg = url_arg + "&cols=bytesWritten&cols=fileHandlers&cols=syscallsWrite&cols=syscallsRead&cols=count"
+    url_arg = url_arg + "&cols=dataSize&cols=indexSize&cols=totalSize&cols=dataFree&cols=rowCount&cols=socketState"
+    url_arg = url_arg + "&cols=socketPort&cols=mplQueryCount&cols=mplQueryLocks&cols=pgLocksWaitTime&cols=pgLocksCount"
+
     from = 0
-    till = 0
-
     from = switch unit
-      when "seconds", "second" then 1
       when "minutes", "minute" then 60
       when "hours", "hour" then 3600
       when "days", "day" then 3600 * 24
       when "months", "month" then 3600 * 24 * 30
       else from = 3600
 
-    range =  "&from=" + (-from * count) + "&until=" + till
-    url = base + urls[component] + range
+    range =  "&from=" + (-from * count) + "&until=0&difference=3600"
+    url = base + encodeURIComponent(url_arg + range)
 
     return url
-
-
-  # Creates the api-share request
-
-  loadShare = (config, msg) ->
-
-    msg.send "Capturing #{config.component}, say cheese..."
-
-    robot.http("#{api}/share/capture?selector=" + encodeURIComponent(config.selector) + "&url=" + encodeURIComponent(config.url))
-    .header('Accept', 'application/json')
-    .header('Authorization', "Bearer #{TOKEN}")
-    .get() (err, res, body) ->
-      try
-        data = JSON.parse(body)
-      catch e
-        msg.send "Invalid api-share response: #{body}"
-
-      if data and 'url' of data
-        msg.send data.url
 
 
   # Respond callback
@@ -110,26 +75,28 @@ module.exports = (robot) ->
 
     commandArray = msg.match[2].replace(/^\s+|\s+$/g, "").split(/\s+/)
 
-    component = commandArray[0]
-    since = commandArray[1]
-
-    if commandArray[2]
-      if commandArray[2].match /^\d+$/ # check if user specified a number
-        count = parseInt commandArray[2]
-        unit = commandArray[3]
+    if commandArray[1]
+      # if 2 words after vividcortex|vc
+      if commandArray[0].match /^\d+$/ # check if user specified a number
+        count = parseInt commandArray[0]
+        unit = commandArray[1]
       else
         count = 1
-        unit = commandArray[2]
+        unit = commandArray[1]
     else
       count = 1
       unit = "hour"
 
-    if component of urls
-      config =
-        component: component
-        selector: "[vc-shareable=\"#{component}\"]"
-        url: getURL(component, since, count, unit, msg)
+    api_url = getURL(count, unit)
+    robot.http(api_url)
+    .header('Accept', 'application/json')
+    .header('Authorization', "Bearer #{TOKEN}")
+    .get() (err, res, body) ->
+      try
+        data = JSON.parse(body)
+      catch e
+        msg.send "Invalid api-share response: #{api_url} #{body}"
 
-      loadShare(config, msg)
-    else
-      msg.send "Component #{component} not defined."
+      if data and 'url' of data
+        msg.send "Top queries by total time on mysql-navisite-2 over last #{count} #{unit}"
+        msg.send data.url


### PR DESCRIPTION
-- Updated to use profiler instead of old top queries, processes, etc...
-- Only works with profiler, so pull out component section
-- Remove seconds as a unit option
-- Remove organization environment var
-- Allow specifying of a single host id